### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -146,7 +146,7 @@ Resources:
     Properties:
       Description: Returns a result by calling AppSync mutation, triggering subscription
       CodeUri: result/
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Handler: index.handler
       Timeout: 10
       Environment:


### PR DESCRIPTION
CloudFormation templates in aws-appsync-long-query have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.